### PR TITLE
Improved win32 console run

### DIFF
--- a/index.js
+++ b/index.js
@@ -138,7 +138,7 @@ let compiler = {
       ], options);
     }
     if (process.platform === 'win32') {
-      const command = `start "${filePath.name}" cmd /C ${compiledPath} & echo.`;
+      const command = `start "${filePath.name}" cmd /C ""${compiledPath}" & echo. & pause "`;
       child_process.exec(command, options);
     } else if (process.platform === 'darwin') {
       child_process.spawn('open', [compiledPath], options);


### PR DESCRIPTION
Now it actually runs for me, probably because I had spaces in the path to my project.
Also added a pause after the run. (maybe make it optional)